### PR TITLE
fix deprecated api for ingress

### DIFF
--- a/cloud-providers/gcp/https-ready-alb/https-ready-alb.yaml
+++ b/cloud-providers/gcp/https-ready-alb/https-ready-alb.yaml
@@ -31,7 +31,7 @@ spec:
     - EXAMPLE.DEV.REPLACEME
 ---
 # https://cloud.google.com/kubernetes-engine/docs/tutorials/http-balancer
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: https-ready-alb-ingress


### PR DESCRIPTION
I was checking all api versions on every resource, wanted to fix any deleted or deprecated ones for master before creating the 
other branches