### PR TITLE
github action to release and automagically update version and sha

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,53 @@
+---
+on:
+  push:
+    tags:
+      - "v*" # Push events to matching v*, i.e. v1.0, v20.15.10
+
+name: Upload Release Asset
+
+jobs:
+  build:
+    name: Upload Release Asset
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout master
+        uses: actions/checkout@v2
+        with:
+          ref: master
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Build project
+        run: |
+          make ci
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: Release ${{ github.ref }}
+          draft: false
+          prerelease: false
+      - name: Upload Release Asset
+        id: upload-release-asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
+          asset_path: ./examples.tar.gz
+          asset_name: examples.tar.gz
+          asset_content_type: application/tar+gzip
+      - name: Commit updated krew yaml
+        id: git_commit
+        run: |
+          git config --global user.email "action@github.com"
+          git config --global user.name "Github Action"
+          git stash -- plugins/examples.yaml
+          git checkout master
+          git stash pop
+          git add plugins/examples.yaml
+          git commit -m "update version references to: ${{ github.ref }}"
+          git push origin master

--- a/Makefile
+++ b/Makefile
@@ -4,13 +4,20 @@ tgz:
 	@tar -uf examples.tar kubectl-examples
 	gzip examples.tar
 
+ver = $(shell git describe --tags)
 sha = $(shell shasum -a 256 < examples.tar.gz|cut -d" " -f1)
 
-update:
+fix-sha:
 	@sed -i 's/sha256: .*$$/sha256: $(sha)/' plugins/examples.yaml
 
-install: clean tgz update
+fix-version:
+	@sed -i 's/v[0-9]\.[0-9]\.[0-9]/$(ver)/' plugins/examples.yaml
+
+install: clean tgz fix-sha
 	kubectl krew install --manifest=plugins/examples.yaml --archive=examples.tar.gz
+
+ci: tgz fix-sha fix-version
+	@echo github action ...
 
 clean:
 	@rm -f examples.tar.gz

--- a/plugins/examples.yaml
+++ b/plugins/examples.yaml
@@ -11,6 +11,16 @@ spec:
     A reference repository of YAML with canonical
     and as-simple-as-possible demonstrations of
     kubernetes functionality and features.
+
+    Usage:
+      interactively selecting resource type:
+        kubectl examples
+
+      interactively selecting yaml:
+        kubectl examples Service
+
+      create a sample ingress while modifying it:
+        kubectl examples Ingress fanout | kubectl create -f - --edit
   platforms:
     - selector:
         matchExpressions:


### PR DESCRIPTION
This PR adds a new github action workflow:
- if there is a new tag matching vX.Y.Z
- create a new release to store examples.tar.gz of all yaml for the krew plugin
- commits an updated examples.yaml (krew plugin descriptor) with updated version num and shasum

## Usage

Once it's merged you just create a new tag (starting with "v") on master, and the workflow does the rest:
- creates a new release matching your tag
- updates the `plugins/examples.yaml` krew manifest and commits it to master

## See it in action

I have tested it on my own fork, see the result:
- See the successful workflow run [logs](https://github.com/lalyos/kubernetes-examples/runs/1102466816?check_suite_focus=true)
- the release created bu the action: [release v0.0.3](https://github.com/lalyos/kubernetes-examples/releases/tag/v0.0.3)
- the commit on master (by github action) fixing url version and shasum: https://github.com/lalyos/kubernetes-examples/commit/ad209ba5444d9a4a56f8974582f0d0ef019df3a8
## Notes

I was trying to use the action: github.com/stefanzweifel/git-auto-commit-action but it seems
this plugin cannot handle pushing to a different branch. It is triggered by the git tag,
so it will be a "detached head" and than couldn't handle switching to the master branch.

see: [action error](https://github.com/lalyos/kubernetes-examples/runs/1102361828?check_suite_focus=true)

So I ended up duck-taping a bunch of git command to implement a safe switch to master.