### PR TITLE
script is functional from git repo dir

### DIFF
--- a/kubectl-examples
+++ b/kubectl-examples
@@ -6,13 +6,14 @@ debug() {
 
 print-example() {
   declare res=$1 pattern=$2
-
-  dir=$(dirname $(readlink $BASH_SOURCE))
+  SELF=${BASH_SOURCE}
+  [[ -L $SELF ]] && SELF=$(readlink ${SELF})
+  dir=$(dirname $SELF)
   debug "dir=${dir}"
 
   if [[ $res == "" ]]; then
     PS3="Resource Type: "
-    select res in $(ls -1 $dir|grep -v kubectl-examples); do
+    select res in [A-LN-Z][a-z]*; do
       debug "res type choosen: ${res}"
       break
     done


### PR DESCRIPTION
Fixing @ianmiell issue when running the script directly in the git repo.

## Note
- readlink on linux and osx works differently and osx has no '-f' option
- the strange glob pattern: `[A-LN-Z][a-z]*` tries to match all names starting with uppercase, except Makefile
  so when there will be some directories starting with `M` it has to be adjusted ...



