### PR TITLE
Fix Jobs default restartPolicy

### DIFF
--- a/Job/simple.yaml
+++ b/Job/simple.yaml
@@ -7,6 +7,7 @@ metadata:
 spec:
   template:
     spec:
+      restartPolicy: Never
       containers:
         - command: ["perl", "-Mbignum=bpi", "-wle", "print bpi(2000)"]
           image: perl

--- a/Job/spec.activeDeadlineSeconds/timeout.yaml
+++ b/Job/spec.activeDeadlineSeconds/timeout.yaml
@@ -8,6 +8,7 @@ spec:
   activeDeadlineSeconds: 100
   template:
     spec:
+      restartPolicy: Never
       containers:
         - command: ["perl", "-Mbignum=bpi", "-wle", "print bpi(2000)"]
           image: perl

--- a/Pod/spec.containers.securityContext/privileged-namespace.yaml
+++ b/Pod/spec.containers.securityContext/privileged-namespace.yaml
@@ -7,7 +7,6 @@ metadata:
 spec:
   hostPID: true
   hostIPC: true
-  hostUTS: true
   hostNetwork: true
   containers:
     - command:

--- a/Pod/spec.containers.volumes.projected/projected.yaml
+++ b/Pod/spec.containers.volumes.projected/projected.yaml
@@ -23,8 +23,8 @@ spec:
               items:
                 - key: username
                   path: my-group/my-username
+                  mode: 511
               name: volumes-projected-secret
-              mode: 511
           - downwardAPI:
               items:
                 - path: "labels"

--- a/Pod/spec.topologySpreadConstraints/topology-spread-constraints-with-node-affinity.yaml
+++ b/Pod/spec.topologySpreadConstraints/topology-spread-constraints-with-node-affinity.yaml
@@ -3,7 +3,7 @@
 kind: Pod
 apiVersion: v1
 metadata:
-  name: topology-spread-constraints/topology-spread-constraints-with-node-affinity-pod
+  name: topology-spread-constraints-with-node-affinity-pod
   labels:
     label1: value1
 spec:

--- a/Pod/spec.volumes.hostPath.type/file-or-create.yaml
+++ b/Pod/spec.volumes.hostPath.type/file-or-create.yaml
@@ -10,6 +10,7 @@ spec:
         - sleep
         - "3600"
       name: busybox
+      image: busybox
       volumeMounts:
         - mountPath: /var/local/aaa
           name: volumes-file-or-create-dir

--- a/PodSecurityPolicy/Ingress/simple.yaml
+++ b/PodSecurityPolicy/Ingress/simple.yaml
@@ -1,6 +1,6 @@
 # Requires an appropriate ingress controller to exist on the cluster for this to take effect
 ---
-apiVersion: networking.k8s.io/v1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: simple
@@ -13,7 +13,5 @@ spec:
           - path: /testpath
             pathType: Prefix
             backend:
-              service:
-                name: test
-                port:
-                  number: 80
+              serviceName: test
+              servicePort: 80

--- a/Service/spec.type/load-balancer.yaml
+++ b/Service/spec.type/load-balancer.yaml
@@ -11,9 +11,4 @@ spec:
     - protocol: TCP
       port: 80
       targetPort: 9376
-  clusterIP: 10.0.171.239
   type: LoadBalancer
-status:
-  loadBalancer:
-    ingress:
-      - ip: 192.0.2.127


### PR DESCRIPTION

When you try to apply some of the Job examples, you get the following error:
```
$ k examples Job out | k apply -f - 

The Job "jobs-timeout-job" is invalid: spec.template.spec.restartPolicy: Unsupported value: "Always": supported values: "OnFailure", "Never"  
```

It is due to some historical k8s decision about PodTemplate defaults:
See:https://github.com/kubernetes/kubernetes/issues/41194#issuecomment-278983306

