### PR TITLE
github action to apply all yaml agains v1.18 apiserver

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,51 @@
+name: k8s-test
+
+on:
+  [push, pull_request]
+
+jobs:
+  apply-all-yaml:
+    runs-on: ubuntu-latest
+
+    # run a single container k8s control plane:
+    # couldn't figure how to specify a custom command for the container
+    # so ended up creating a custom image
+    services:
+      k3s:
+        image: lalyos/k3s:hack
+        ports:
+          - 8080:8080
+        options: >-
+          --privileged
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: kubectl version
+        run: |
+          sleep 5
+          type kubectl
+          kubectl version || true | tee apply.txt
+          kubectl create sa default 2>/dev/null || true
+          kubectl get sa -A
+
+      - name: check all yaml
+        run: |
+          for y in [A-Z][a-z]*/**/*.yaml; do
+            echo === apply: ${y}
+            if kubectl apply -f $y ;then
+            kubectl delete -f $y &
+          else
+            echo === ERROR: $y
+          fi
+          done |& tee apply.txt
+
+      - name: upload artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: apply-test-all-yaml
+          path: apply.txt
+
+      - name: check apply log for error
+        run: |
+          grep -B1 '=== ERROR' apply.txt && exit 1


### PR DESCRIPTION
This PR adds a github action to validate all manifest by `kubectl apply -f`
So additionally over yamllint, its a real validation.

- It create a k3s [service-container](https://docs.github.com/en/actions/configuring-and-managing-workflows/about-service-containers). Think about it as a single container lightweight throwaway k8s server
- all manifest is validates by `kubectl apply -f` and then immediately deleted 
- creates an artifact [apply-test-all-yaml](https://github.com/lalyos/kubernetes-examples/suites/1190137741/artifacts/17501949) with the output of applys

## See it in action

- This is an action run with failing apply: [lalyos/kubernetes-examples/runs/1113122021](https://github.com/lalyos/kubernetes-examples/runs/1113122021), or download the [artifact](https://github.com/lalyos/kubernetes-examples/suites/1190137741/artifacts/17501949)
- This is an action run with the fixing PT: [lalyos/kubernetes-examples/runs/1113720147](https://github.com/lalyos/kubernetes-examples/runs/1113720147) or download the [artifact](https://github.com/lalyos/kubernetes-examples/suites/1190766170/artifacts/17517625)
