### PR TITLE
Proposed code of conduct and contributing guidelines.

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,134 @@
+# Code of Conduct
+
+All participants to the Kubernetes Examples project are required to comply with the following code
+of conduct, which is based on v2.0 of the [Contributor
+Covenant](https://www.contributor-covenant.org/).
+
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity
+and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the
+  overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or
+  advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email
+  address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to ian.miell@container-solutions.com or any of the project admins.
+
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series
+of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or
+permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior,  harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within
+the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.0, available at
+https://www.contributor-covenant.org/version/2/0/code_of_conduct.html.
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct
+enforcement ladder](https://github.com/mozilla/diversity).
+
+[homepage]: https://www.contributor-covenant.org
+
+For answers to common questions about this code of conduct, see the FAQ at
+https://www.contributor-covenant.org/faq. Translations are available at
+https://www.contributor-covenant.org/translations.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,50 @@
+# Contributing To Kubernetes Examples
+
+Firstly, big thanks for considering contributing to the project. We really hope to make this into a
+community project and to do that we need your help!
+
+## Code of Conduct
+
+We are serious about making this a welcoming, happy project. We will not tolerate discrimination,
+aggressive or insulting behaviour.
+
+To this end, the project and everyone participating in it is bound by the [Code of
+Conduct](CODE_OF_CONDUCT.md). By participating, you are expected to uphold this code. Please report
+unacceptable behaviour to any of the project admins or adrian.mouat@container-solutions.com.
+
+## Bugs/Mistakes
+
+If there is mistake in one of the YAML files, please [open an
+issue](https://github.com/ContainerSolutions/kuberntes-examples/issues). If the YAML doesn't work on
+a given platform, please provide details of the platform. If it's a simple fix e.g. the API version
+needs updated, please consider opening a PR instead. 
+
+## Contributing New Examples
+
+New examples are warmly welcomed! But please make sure they are in-keeping with the style of the
+existing examples. All examples should be:
+
+    - As simple as possible to illustrate the functionality
+
+    - Self-contained (ie limited to one .yaml file)
+
+    - Non-conflicting (eg resource names are unique)
+
+    - Clear (eg resource names are verbose and unambiguous)
+ 
+Please open a Pull Request to contribute new examples.
+
+## Pull Request Process
+
+All PRs have to be reviewed and signed off by another developer before being merged to the master
+branch. This review may ask for some changes - please don't be alarmed or upset at this; it is
+expected that all PRs will need tweaks and a normal part of the process.
+
+Be aware that this repo uses the [MIT licence](LICENSE).
+
+### Thanks
+
+These guidelines were best on several sources, including
+[Atom](https://github.com/atom/atom/blob/master/CONTRIBUTING.md), [PurpleBooth's
+advice](https://gist.github.com/PurpleBooth/b24679402957c63ec426) and the [Contributor
+Covenant](https://www.contributor-covenant.org/).


### PR DESCRIPTION
This PR is based on the Trow repo, modified for Kubernetes Examples.

We need this in place if we want to take advantage of hacktoberfest.