### PR TITLE
Add Deployment example with environment variables

### DIFF
--- a/Deployment/simple-deployment-with-environment.yaml
+++ b/Deployment/simple-deployment-with-environment.yaml
@@ -35,4 +35,3 @@ spec:
                 configMapKeyRef:
                   name: kafka_config_map
                   key: topic
-            

--- a/Deployment/simple-deployment-with-environment.yaml
+++ b/Deployment/simple-deployment-with-environment.yaml
@@ -1,0 +1,38 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: deployments-simple-deployment-with-environment-deployment
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: deployments-simple-deployment-with-environment-app
+  template:
+    metadata:
+      labels:
+        app: deployments-simple-deployment-with-environment-app
+    spec:
+      containers:
+        - name: busybox
+          image: busybox
+          command:
+            - sleep
+            - "3600"
+          env:
+            # Plain Text ENV
+            - name: DEMO_GREETING
+              value: "Hello from the environment"
+            # Load from a secret
+            - name: DATABASE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: database_secrets
+                  key: password
+            # Load from a configMap
+            - name: KAFKA_TOPIC
+              valueFrom:
+                configMapKeyRef:
+                  name: kafka_config_map
+                  key: topic
+            


### PR DESCRIPTION
I often forget syntax for how to add environment variables to a Deployment. 

I thought others might have this problem too, and have added a Deployment example with environment variables for plain text, and loading from a secret * configMap.