### PR TITLE
fix: typo in pod's volume claimName

### DIFF
--- a/Pod/spec.volumes.persistentVolumeClaim/pod-pvc.yaml
+++ b/Pod/spec.volumes.persistentVolumeClaim/pod-pvc.yaml
@@ -13,4 +13,4 @@ spec:
   volumes:
     - name: volume-pvc
       persistentVolumeClaim:
-        claimName: persitent-volume-claim
+        claimName: persistent-volume-claim


### PR DESCRIPTION
Fixed a typo in the persistentVolumeClaim claimName of the PVC Pod example