### PR TITLE
Api version updates

### DIFF
--- a/CronJob/simple.yaml
+++ b/CronJob/simple.yaml
@@ -1,20 +1,21 @@
 ---
 # https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: cronjob-simple
 spec:
-  schedule: "*/1 * * * *"
+  schedule: "* * * * *"
   jobTemplate:
     spec:
       template:
         spec:
           containers:
-            - args:
+            - command:
                 - /bin/sh
                 - -c
                 - date; echo Hello from the Kubernetes cluster cronjob
-              image: busybox
+              image: busybox:1.28
+              imagePullPolicy: IfNotPresent
               name: cronjob-simple-container
           restartPolicy: OnFailure

--- a/Endpoints/endpoint-slice.yaml
+++ b/Endpoints/endpoint-slice.yaml
@@ -1,6 +1,6 @@
 ---
 # https://kubernetes.io/docs/concepts/services-networking/endpoint-slices/
-apiVersion: discovery.k8s.io/v1beta1
+apiVersion: discovery.k8s.io/v1
 kind: EndpointSlice
 metadata:
   name: endpoint-slices
@@ -15,6 +15,5 @@ endpoints:
     conditions:
       ready: true
     hostname: pod-1
-    topology:
-      kubernetes.io/hostname: node-1
-      topology.kubernetes.io/zone: us-west2-a
+    nodeName: node-1
+    zone: us-west2-a

--- a/PodDisruptionBudget/pod-disruption-budget-max-unavailable.yaml
+++ b/PodDisruptionBudget/pod-disruption-budget-max-unavailable.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: pod-disruption-budget-max-unavailable-simple

--- a/PodDisruptionBudget/pod-disruption-budget-min-available.yaml
+++ b/PodDisruptionBudget/pod-disruption-budget-min-available.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: pod-disruption-budget-min-available-simple

--- a/PodSecurityPolicy/restricted.yaml
+++ b/PodSecurityPolicy/restricted.yaml
@@ -9,15 +9,8 @@ metadata:
   annotations:
     seccomp.security.alpha.kubernetes.io/allowedProfileNames: 'docker/default,runtime/default'
     apparmor.security.beta.kubernetes.io/allowedProfileNames: 'runtime/default'
-    seccomp.security.alpha.kubernetes.io/defaultProfileName: 'runtime/default'
     apparmor.security.beta.kubernetes.io/defaultProfileName: 'runtime/default'
 spec:
-  allowedHostPaths:
-    # This allows "/foo", "/foo/", "/foo/bar" etc., but
-    # disallows "/fool", "/etc/foo" etc.
-    # "/foo/../" is never valid.
-    - pathPrefix: "/foo"
-      readOnly: true  # only allow read-only mounts
   allowPrivilegeEscalation: false
   # This is redundant with non-root + disallow privilege escalation,
   # but we can provide it for defense in depth.
@@ -54,5 +47,7 @@ spec:
     - 'projected'
     - 'secret'
     - 'downwardAPI'
-    # Assume that persistentVolumes set up by the cluster admin are safe to use.
+    # Assume that ephemeral CSI drivers & persistentVolumes set up by the cluster admin are safe to use.
     - 'persistentVolumeClaim'
+    - 'csi'
+    - 'ephemeral'


### PR DESCRIPTION
Fixes #49 

Updated the API versions in the examples with the latest versions. 

- Couldn't find any examples related to `PodPreset` neither in the repo nor in the Kubernetes docs. This is removed.
- I haven't updated the `cloud provider` and `plugin` resources.
- We need to discuss what to do with `PodSecurityPolicy` resources because of the deprecation. It will be removed from the API in the next release but we skip these resources in the CI with `-ignore-missing-schemas` option because `kubeconform` doesn't have it in its schema in the master version for Kubernetes.